### PR TITLE
allow onSubmit to get actions to update form state

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Form is top most component, all other components should be its child.
 
 #### Form Props
 
-* `onSubmit: (value: Object) => void`
+* `onSubmit: (value: Object, actions: FormActions ) => void`
 * `initialValues?: Object`
 * `validations?: (values: Object) => void | Object | Promise<*>`
 * `validateOnChange?: boolean`

--- a/src/Form.js
+++ b/src/Form.js
@@ -4,7 +4,7 @@ import { equals } from 'ramda'
 import warning from 'warning'
 import { ZenFormProvider } from './ZenFormContext'
 import { setIn, isPromise, isFunction, setNestedValues } from './utils'
-import type { FormProps as Props, ZenFormContext, FormRenderProps } from '../typedef/types.js.flow'
+import type { FormProps as Props, ZenFormContext, FormRenderProps, FormActions } from '../typedef/types.js.flow'
 
 type State = {
   values: Object,
@@ -178,7 +178,7 @@ class Form extends React.Component<Props, State> {
         maybePromisedErrors.then(
           () => {
             this.setState({ errors: {} })
-            onSubmit(values)
+            onSubmit(values, this.getFormActions())
           },
           errors =>
             this.setState({ errors, touched: setNestedValues(errors, true), isSubmitting: false })
@@ -192,16 +192,33 @@ class Form extends React.Component<Props, State> {
         })
 
         if (isValid) {
-          onSubmit(values)
+          onSubmit(values, this.getFormActions())
         }
       }
     } else {
-      onSubmit(values)
+      onSubmit(values, this.getFormActions())
     }
   }
 
   resetForm = () => {
     this.setState(this.initialState)
+  }
+
+  getFormActions = (): FormActions => {
+    return {
+      setFieldValue: this.setFieldValue,
+      setMultipleFieldValues: this.setMultipleFieldValues,
+      setFieldError: this.setFieldError,
+      setMultipleFieldErrors: this.setMultipleFieldErrors,
+      setFieldTouched: this.setFieldTouched,
+      setMultipleFieldTouched: this.setMultipleFieldTouched,
+      setFieldData: this.setFieldData,
+      setMultipleFieldData: this.setMultipleFieldData,
+      setActiveField: this.setActiveField,
+      setZenFormState: this.setZenFormState,
+      runValidations: this.runValidations,
+      resetForm: this.resetForm,
+    }
   }
 
   render() {

--- a/src/Form.js
+++ b/src/Form.js
@@ -145,6 +145,10 @@ class Form extends React.Component<Props, State> {
     this.setState(newState, callback)
   }
 
+  setSubmitting = (isSubmitting: boolean) => {
+    this.setState({ isSubmitting })
+  }
+
   runValidations = (values: any) => {
     const { validations } = this.props
 
@@ -218,6 +222,7 @@ class Form extends React.Component<Props, State> {
       setZenFormState: this.setZenFormState,
       runValidations: this.runValidations,
       resetForm: this.resetForm,
+      setSubmitting: this.setSubmitting
     }
   }
 

--- a/typedef/types.js.flow
+++ b/typedef/types.js.flow
@@ -49,7 +49,7 @@ export type ZenFormContext = {
 } & FieldUpdateActions
 
 export type FormProps = {
-  onSubmit: (value: Object) => void,
+  onSubmit: (value: Object, actions: FormActions) => void,
   initialValues?: Object,
   validations?: (values: Object) => void | Object | Promise<*>,
   validateOnChange?: boolean,
@@ -178,4 +178,10 @@ export type FormObserverAuxProps = {
 
 export type FormObserverProps = {
   onChange?: (args: FormObserverData) => void,
+}
+
+export type FormActions = FieldUpdateActions & {
+  setZenFormState: (s: any, cb?: () => void) => void,
+  runValidations: (values: Object) => void,
+  resetForm: () => void,
 }

--- a/typedef/types.js.flow
+++ b/typedef/types.js.flow
@@ -184,4 +184,5 @@ export type FormActions = FieldUpdateActions & {
   setZenFormState: (s: any, cb?: () => void) => void,
   runValidations: (values: Object) => void,
   resetForm: () => void,
+  setSubmitting: (boolean) => void,
 }


### PR DESCRIPTION
## enhancement
I made onSubmit enable to take some actions to update form state as Formik does.
https://github.com/jaredpalmer/formik/blob/586a7e478326d30afaf210206a9cbd0597c19383/src/Formik.tsx#L437

### my use case would be

I wanna use `Form.resetForm()` in `onSubmit`
``` 
<Form
  onSubmit={(values, actions) => {
      sendRequest(values).then(() => {
          actions.resetForm()
      })
  }}
>
...
</Form>
```